### PR TITLE
Add createdDateTime and lastUpdated fields

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -118,6 +118,8 @@ public class CaseAndUacReceiver {
     caseDetails.setLongitude(collectionCase.getAddress().getLongitude());
     caseDetails.setUprn(collectionCase.getAddress().getUprn());
     caseDetails.setRegion(collectionCase.getAddress().getRegion());
+    caseDetails.setCreatedDateTime(collectionCase.getCreatedDateTime());
+    caseDetails.setLastUpdated(collectionCase.getLastUpdated());
     // Nope don't add new stuff here... look at the comment below...
 
     // Below this line is extra data potentially needed by Action Processor - can be ignored by RH

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -1,9 +1,8 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.time.OffsetDateTime;
 import lombok.Data;
 import uk.gov.ons.census.action.model.entity.CaseMetadata;
-
-import java.time.OffsetDateTime;
 
 @Data
 public class CollectionCase {

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -12,6 +12,9 @@ public class CollectionCase {
   private String collectionExerciseId;
   private Address address;
   private String actionableFrom;
+  private OffsetDateTime createdDateTime;
+  private OffsetDateTime lastUpdated;
+
   // Below this line is extra data potentially needed by Action Processor - can be ignored by RH
   private String actionPlanId;
   private String treatmentCode;

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -3,6 +3,8 @@ package uk.gov.ons.census.action.model.dto;
 import lombok.Data;
 import uk.gov.ons.census.action.model.entity.CaseMetadata;
 
+import java.time.OffsetDateTime;
+
 @Data
 public class CollectionCase {
   private String id;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -114,10 +114,8 @@ public class Case {
   private boolean surveyLaunched;
 
   @Column(columnDefinition = "timestamp with time zone")
-  @CreationTimestamp
   private OffsetDateTime createdDateTime;
 
   @Column(columnDefinition = "timestamp with time zone")
-  @UpdateTimestamp
   private OffsetDateTime lastUpdated;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -1,14 +1,14 @@
 package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+import javax.persistence.*;
 import java.time.OffsetDateTime;
 import java.util.UUID;
-import javax.persistence.*;
-import javax.persistence.Entity;
-import javax.persistence.Index;
-import javax.persistence.Table;
-import lombok.Data;
-import org.hibernate.annotations.*;
 
 @Data
 @Entity

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -1,14 +1,13 @@
 package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import javax.persistence.*;
 import lombok.Data;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
-
-import javax.persistence.*;
-import java.time.OffsetDateTime;
-import java.util.UUID;
 
 @Data
 @Entity

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -1,12 +1,16 @@
 package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
 import lombok.Data;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-import org.hibernate.annotations.TypeDefs;
+import org.hibernate.annotations.*;
 
 @Data
 @Entity

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -110,4 +110,12 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean surveyLaunched;
+
+  @Column(columnDefinition = "timestamp with time zone")
+  @CreationTimestamp
+  private OffsetDateTime createdDateTime;
+
+  @Column(columnDefinition = "timestamp with time zone")
+  @UpdateTimestamp
+  private OffsetDateTime lastUpdated;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -1,14 +1,12 @@
 package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
-
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.*;
 import javax.persistence.Entity;
 import javax.persistence.Index;
 import javax.persistence.Table;
-
 import lombok.Data;
 import org.hibernate.annotations.*;
 

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -416,6 +416,8 @@ public class CaseAndUacReceiverTest {
     newCase.setMetadata(collectionCase.getMetadata());
     newCase.setSkeleton(collectionCase.isSkeleton());
     newCase.setPrintBatch(collectionCase.getPrintBatch());
+    newCase.setCreatedDateTime(collectionCase.getCreatedDateTime());
+    newCase.setLastUpdated(collectionCase.getLastUpdated());
     return newCase;
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiverIT.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.action.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.jeasy.random.EasyRandom;
@@ -52,7 +53,7 @@ public class FulfilmentRequestReceiverIT {
   public void testQuestionnaireFulfilment() throws InterruptedException {
 
     // Given
-    Case fulfillmentCase = this.setUpCaseAndSaveInDB();
+    Case fulfillmentCase = setUpCaseAndSaveInDB();
     ResponseManagementEvent actionFulfilmentEvent =
         getResponseManagementEvent(fulfillmentCase.getCaseId(), "P_OR_H1");
 
@@ -110,7 +111,8 @@ public class FulfilmentRequestReceiverIT {
 
   private Case setUpCaseAndSaveInDB() {
     Case fulfilmentCase = easyRandom.nextObject(Case.class);
-    caseRepository.saveAndFlush(fulfilmentCase);
-    return fulfilmentCase;
+    fulfilmentCase.setCreatedDateTime(OffsetDateTime.now());
+    fulfilmentCase.setLastUpdated(OffsetDateTime.now());
+    return caseRepository.saveAndFlush(fulfilmentCase);
   }
 }


### PR DESCRIPTION
# Motivation and Context
New fields in CASE_UPDATED and CASE_CREATED events

# What has changed
New fields added
Tests amended to check for new field values

# How to test?
Build other repos on card and run ATs

# Links
https://trello.com/c/n6FwePKv/1052-waiting-on-action-processor-casecreated-caseupdated-events-should-contain-the-createddatetime-field-5

https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Response+Management+Event+Dictionary