### PR TITLE
Log useful stacktrace line

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/client/ExceptionManagerClient.java
+++ b/src/main/java/uk/gov/ons/census/action/client/ExceptionManagerClient.java
@@ -23,11 +23,16 @@ public class ExceptionManagerClient {
   private String port;
 
   public ExceptionReportResponse reportException(
-      String messageHash, String service, String queue, Throwable cause) {
+      String messageHash,
+      String service,
+      String queue,
+      Throwable cause,
+      String stackTraceRootCause) {
 
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setExceptionClass(cause.getClass().getName());
     exceptionReport.setExceptionMessage(cause.getMessage());
+    exceptionReport.setExceptionRootCause(stackTraceRootCause);
     exceptionReport.setMessageHash(messageHash);
     exceptionReport.setService(service);
     exceptionReport.setQueue(queue);

--- a/src/main/java/uk/gov/ons/census/action/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/ManagedMessageRecoverer.java
@@ -67,8 +67,11 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
         messageHash = bytesToHexString(digest.digest(rawMessageBody));
       }
 
+      String stackTraceRootCause =
+          findUsefulRootCauseInStackTrace(listenerExecutionFailedException.getCause());
       ExceptionReportResponse reportResult =
-          getExceptionReportResponse(listenerExecutionFailedException, messageHash);
+          getExceptionReportResponse(
+              listenerExecutionFailedException, messageHash, stackTraceRootCause);
 
       if (skipMessage(
           reportResult, messageHash, rawMessageBody, listenerExecutionFailedException, message)) {
@@ -77,7 +80,11 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
 
       peekMessage(reportResult, messageHash, rawMessageBody);
       logMessage(
-          reportResult, listenerExecutionFailedException.getCause(), messageHash, rawMessageBody);
+          reportResult,
+          listenerExecutionFailedException.getCause(),
+          messageHash,
+          rawMessageBody,
+          stackTraceRootCause);
 
       // Reject the original message where it'll be retried at some future point in time
       throw new AmqpRejectAndDontRequeueException(
@@ -89,7 +96,9 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
   }
 
   private ExceptionReportResponse getExceptionReportResponse(
-      ListenerExecutionFailedException listenerExecutionFailedException, String messageHash) {
+      ListenerExecutionFailedException listenerExecutionFailedException,
+      String messageHash,
+      String stackTraceRootCause) {
     ExceptionReportResponse reportResult = null;
     try {
       reportResult =
@@ -97,7 +106,8 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
               messageHash,
               serviceName,
               queueName,
-              listenerExecutionFailedException.getCause().getCause());
+              listenerExecutionFailedException.getCause().getCause(),
+              stackTraceRootCause);
     } catch (Exception exceptionManagerClientException) {
       log.with("reason", exceptionManagerClientException.getMessage())
           .warn(
@@ -173,7 +183,8 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       ExceptionReportResponse reportResult,
       Throwable cause,
       String messageHash,
-      byte[] rawMessageBody) {
+      byte[] rawMessageBody,
+      String stackTraceRootCause) {
     if (reportResult != null && !reportResult.isLogIt()) {
       return;
     }
@@ -183,7 +194,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
           .with("valid_json", validateJson(rawMessageBody))
           .error("Could not process message", cause);
     } else {
-      String stackTraceRootCause = findUsefulRootCauseInStackTrace(cause);
       log.with("message_hash", messageHash)
           .with("valid_json", validateJson(rawMessageBody))
           .with("cause", cause.getMessage())

--- a/src/main/java/uk/gov/ons/census/action/model/dto/ExceptionReport.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/ExceptionReport.java
@@ -9,4 +9,5 @@ public class ExceptionReport {
   private String queue;
   private String exceptionClass;
   private String exceptionMessage;
+  private String exceptionRootCause;
 }

--- a/src/test/java/uk/gov/ons/census/action/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/ManagedMessageRecovererTest.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.action.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -41,17 +42,22 @@ public class ManagedMessageRecovererTest {
     exceptionReportResponse.setLogIt(true);
     exceptionReportResponse.setPeek(false);
     exceptionReportResponse.setSkipIt(false);
-    when(exceptionManagerClient.reportException(any(), any(), any(), any()))
+    when(exceptionManagerClient.reportException(any(), any(), any(), any(), any()))
         .thenReturn(exceptionReportResponse);
 
+    // When
     try {
-      // When
       underTest.recover(message, failedException);
     } catch (AmqpRejectAndDontRequeueException expectedException) {
+
       // Then
       verify(exceptionManagerClient)
           .reportException(
-              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+              eq(MESSAGE_HASH),
+              eq("test service"),
+              eq("test queue"),
+              eq(cause.getCause()),
+              contains("at uk.gov.ons.census.action.messaging.ManagedMessageRecovererTest"));
 
       verifyNoMoreInteractions(exceptionManagerClient);
 
@@ -61,7 +67,6 @@ public class ManagedMessageRecovererTest {
 
   @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecoverExceptionManagerUnavailable() {
-    // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
@@ -72,20 +77,22 @@ public class ManagedMessageRecovererTest {
     ListenerExecutionFailedException failedException =
         new ListenerExecutionFailedException("test error message", cause, message);
 
-    when(exceptionManagerClient.reportException(any(), any(), any(), any()))
+    when(exceptionManagerClient.reportException(any(), any(), any(), any(), any()))
         .thenThrow(new RuntimeException());
 
     try {
-      // When
       underTest.recover(message, failedException);
     } catch (AmqpRejectAndDontRequeueException expectedException) {
-      // Then
+
       verify(exceptionManagerClient)
           .reportException(
-              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+              eq(MESSAGE_HASH),
+              eq("test service"),
+              eq("test queue"),
+              eq(cause.getCause()),
+              contains("at uk.gov.ons.census.action.messaging.ManagedMessageRecovererTest"));
 
       verifyNoMoreInteractions(exceptionManagerClient);
-
       throw expectedException;
     }
   }
@@ -110,14 +117,18 @@ public class ManagedMessageRecovererTest {
     exceptionReportResponse.setLogIt(true);
     exceptionReportResponse.setPeek(false);
     exceptionReportResponse.setSkipIt(true);
-    when(exceptionManagerClient.reportException(any(), any(), any(), any()))
+    when(exceptionManagerClient.reportException(any(), any(), any(), any(), any()))
         .thenReturn(exceptionReportResponse);
 
     underTest.recover(message, failedException);
 
     verify(exceptionManagerClient)
         .reportException(
-            eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+            eq(MESSAGE_HASH),
+            eq("test service"),
+            eq("test queue"),
+            eq(cause.getCause()),
+            contains("at uk.gov.ons.census.action.messaging.ManagedMessageRecovererTest"));
 
     ArgumentCaptor<SkippedMessage> skippedMessageArgumentCaptor =
         ArgumentCaptor.forClass(SkippedMessage.class);
@@ -138,7 +149,6 @@ public class ManagedMessageRecovererTest {
 
   @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecoverPeek() {
-    // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
     ManagedMessageRecoverer underTest =
         new ManagedMessageRecoverer(
@@ -157,17 +167,20 @@ public class ManagedMessageRecovererTest {
     exceptionReportResponse.setLogIt(false);
     exceptionReportResponse.setPeek(true);
     exceptionReportResponse.setSkipIt(false);
-    when(exceptionManagerClient.reportException(any(), any(), any(), any()))
+    when(exceptionManagerClient.reportException(any(), any(), any(), any(), any()))
         .thenReturn(exceptionReportResponse);
 
     try {
-      // When
       underTest.recover(message, failedException);
     } catch (AmqpRejectAndDontRequeueException expectedException) {
-      // Then
+
       verify(exceptionManagerClient)
           .reportException(
-              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+              eq(MESSAGE_HASH),
+              eq("test service"),
+              eq("test queue"),
+              eq(cause.getCause()),
+              contains("at uk.gov.ons.census.action.messaging.ManagedMessageRecovererTest"));
 
       verify(exceptionManagerClient)
           .respondToPeek(eq(MESSAGE_HASH), eq("test message body".getBytes()));


### PR DESCRIPTION
# Motivation and Context
When we get errors like null pointer exceptions, it's often unclear where exactly in the code things have gone wrong. The stacktrace has the detail, but we don't log stacktraces by default, and stack traces are often laborious to trawl through.

# What has changed
Added code to trawl the stacktrace and extract the 'root cause' in our code of where the NPE or other type of exception originated from, which should allow us to more quickly diagnose & fix problems.

# How to test?
Send in a bad message (missing some mandatory data, for example) and check the logs - there should be details about the line of code which threw the exception (NOT the cause... the RESULT of bad data being sent into RM which shouldn't happen but does happen when we're testing).

# Links
Trello: https://trello.com/c/DQgYqRA8