### PR TITLE
(IC03.1/IC04.1) Generate CE UNIT Addressed ICL Print Files

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -26,11 +26,11 @@ public enum ActionType {
 
   // Individual addressed initial contact letters for CE Units
   CE_IC03_1(
-          ActionHandler.PRINTER,
-          "D_ICA_ICLR1"), // Individual ICL with UAC for England (Hand Delivery) Addressed
+      ActionHandler.PRINTER,
+      "D_ICA_ICLR1"), // Individual ICL with UAC for England (Hand Delivery) Addressed
   CE_IC04_1(
-          ActionHandler.PRINTER,
-          "D_ICA_ICLR2B"), // Individual ICL with UAC for Wales (Hand Delivery) Addressed
+      ActionHandler.PRINTER,
+      "D_ICA_ICLR2B"), // Individual ICL with UAC for Wales (Hand Delivery) Addressed
 
   // Initial contact letters for SPGs
   SPG_IC11(ActionHandler.PRINTER, "P_ICCE_ICL1"),

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -25,8 +25,12 @@ public enum ActionType {
   CE_IC06(ActionHandler.PRINTER, "D_CE4A_ICLS4"),
 
   // Individual addressed initial contact letters for CE Units
-  CE_IC03_1(ActionHandler.PRINTER, "D_ICA_ICLR1"),
-  CE_IC04_1(ActionHandler.PRINTER, "D_ICA_ICLR2B"),
+  CE_IC03_1(
+          ActionHandler.PRINTER,
+          "D_ICA_ICLR1"), // Individual ICL with UAC for England (Hand Delivery) Addressed
+  CE_IC04_1(
+          ActionHandler.PRINTER,
+          "D_ICA_ICLR2B"), // Individual ICL with UAC for Wales (Hand Delivery) Addressed
 
   // Initial contact letters for SPGs
   SPG_IC11(ActionHandler.PRINTER, "P_ICCE_ICL1"),


### PR DESCRIPTION
# Motivation and Context
These ActionTypes needed to be changed to generate and address line for each instance of expected response recorded against the unit whereas before they were not dependent on expected capacity

# What has changed
Descriptions added to ActionTypes

# Links
https://trello.com/c/FPqeHTfQ/1046-ic031-i041-generate-ce-unit-addressed-icl-print-files-3
https://collaborate2.ons.gov.uk/confluence/display/SDC/RM+Census+Initial+Contact+Run+Book+-+2021
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=34832584