### PR TITLE
Update case metadata entity

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class CaseMetadata {
 
   private Boolean secureEstablishment;
+  private String channel;
 }


### PR DESCRIPTION
# Motivation and Context
The case metadata can now contain the channel of creation for HI cases.

# What has changed
* Update case metadata entity

# How to test?
At AT's PR

# Links
https://trello.com/c/Rc8d1RmE/983-reminders-individual-response-8
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/296