### PR TITLE
Use UUID type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -92,9 +92,9 @@ public class CaseAndUacReceiver {
   }
 
   private void processCaseUpdatedEvent(CollectionCase collectionCase) {
-    String caseId = collectionCase.getId();
+    UUID caseId = collectionCase.getId();
 
-    Optional<Case> cazeOpt = caseRepository.findByCaseId(UUID.fromString(caseId));
+    Optional<Case> cazeOpt = caseRepository.findByCaseId(caseId);
 
     if (cazeOpt.isEmpty()) {
       throw new RuntimeException(String.format(CASE_NOT_FOUND_ERROR, caseId));
@@ -107,7 +107,7 @@ public class CaseAndUacReceiver {
 
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {
     caseDetails.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
-    caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
+    caseDetails.setCaseId(collectionCase.getId());
     caseDetails.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     caseDetails.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     caseDetails.setAddressLine2(collectionCase.getAddress().getAddressLine2());

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -1,23 +1,24 @@
 package uk.gov.ons.census.action.model.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.Data;
 import uk.gov.ons.census.action.model.entity.CaseMetadata;
 
 @Data
 public class CollectionCase {
-  private String id;
+  private UUID id;
   private String caseRef;
   private String caseType;
   private String survey;
-  private String collectionExerciseId;
+  private UUID collectionExerciseId;
   private Address address;
   private String actionableFrom;
   private OffsetDateTime createdDateTime;
   private OffsetDateTime lastUpdated;
 
   // Below this line is extra data potentially needed by Action Processor - can be ignored by RH
-  private String actionPlanId;
+  private UUID actionPlanId;
   private String treatmentCode;
   private String oa;
   private String lsoa;

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -8,5 +9,5 @@ public class Event {
   private String source;
   private String channel;
   private String dateTime;
-  private String transactionId;
+  private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class FieldCaseSelected {
   private long caseRef;
-  private String actionRuleId;
+  private UUID actionRuleId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Uac.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Uac.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -10,6 +11,6 @@ public class Uac {
   private String questionnaireId;
   private String caseType;
   private String region;
-  private String caseId;
-  private String collectionExerciseId;
+  private UUID caseId;
+  private UUID collectionExerciseId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -83,9 +83,9 @@ public class Case {
 
   @Column private Integer ceActualResponses;
 
-  @Column private String collectionExerciseId;
+  @Column private UUID collectionExerciseId;
 
-  @Column private String actionPlanId;
+  @Column private UUID actionPlanId;
 
   @Column(name = "receipt_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean receiptReceived;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
@@ -24,7 +24,7 @@ public class UacQidLink {
   @Column private String uac;
 
   @Column(name = "case_id")
-  private String caseId;
+  private UUID caseId;
 
   @Column private boolean active;
 }

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -262,9 +262,10 @@ public class CaseAndUacReceiverTest {
     Event event = new Event();
     event.setType(EventType.UAC_UPDATED);
     Uac uac = new Uac();
+    UUID test_case_id = UUID.randomUUID();
     uac.setQuestionnaireId("Test QID");
     uac.setUac("Test UAC");
-    uac.setCaseId("Test Case Id");
+    uac.setCaseId(test_case_id);
     uac.setActive(true);
     Payload payload = new Payload();
     payload.setUac(uac);
@@ -281,7 +282,7 @@ public class CaseAndUacReceiverTest {
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacQidLinkRepository).save(uacQidLinkArgumentCaptor.capture());
     UacQidLink actualUacQidLink = uacQidLinkArgumentCaptor.getValue();
-    assertEquals("Test Case Id", actualUacQidLink.getCaseId());
+    assertEquals(test_case_id, actualUacQidLink.getCaseId());
     assertEquals("Test QID", actualUacQidLink.getQid());
     assertEquals("Test UAC", actualUacQidLink.getUac());
     assertEquals(true, actualUacQidLink.isActive());
@@ -293,10 +294,12 @@ public class CaseAndUacReceiverTest {
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     Event event = new Event();
     event.setType(EventType.UAC_UPDATED);
+    UUID updated_test_case_id = UUID.randomUUID();
+    UUID test_case_id = UUID.randomUUID();
     Uac uac = new Uac();
     uac.setQuestionnaireId("Test QID");
     uac.setUac("Test UAC");
-    uac.setCaseId("Updated Test Case ID");
+    uac.setCaseId(updated_test_case_id);
     uac.setActive(false);
     Payload payload = new Payload();
     payload.setUac(uac);
@@ -306,7 +309,7 @@ public class CaseAndUacReceiverTest {
         new CaseAndUacReceiver(caseRepository, uacQidLinkRepository, fulfilmentRequestService);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setActive(true);
-    uacQidLink.setCaseId("Change me");
+    uacQidLink.setCaseId(test_case_id);
     when(uacQidLinkRepository.findByQid(anyString())).thenReturn(Optional.of(uacQidLink));
 
     // When
@@ -317,7 +320,7 @@ public class CaseAndUacReceiverTest {
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacQidLinkRepository).save(uacQidLinkArgumentCaptor.capture());
     UacQidLink actualUacQidLink = uacQidLinkArgumentCaptor.getValue();
-    assertEquals("Updated Test Case ID", actualUacQidLink.getCaseId());
+    assertEquals(updated_test_case_id, actualUacQidLink.getCaseId());
     assertEquals(false, actualUacQidLink.isActive());
   }
 
@@ -347,10 +350,7 @@ public class CaseAndUacReceiverTest {
         easyRandom.nextObject(ResponseManagementEvent.class);
 
     responseManagementEvent.getPayload().getCollectionCase().setCaseRef("1234567890");
-    responseManagementEvent
-        .getPayload()
-        .getCollectionCase()
-        .setId("d09ac28e-d62f-4cdd-a5f9-e366e05f0fcd");
+    responseManagementEvent.getPayload().getCollectionCase().setId(UUID.randomUUID());
     responseManagementEvent.getPayload().getUac().setQuestionnaireId("123");
     responseManagementEvent.getPayload().getCollectionCase().setReceiptReceived(false);
     responseManagementEvent.getPayload().getCollectionCase().setRefusalReceived(null);
@@ -363,10 +363,7 @@ public class CaseAndUacReceiverTest {
         easyRandom.nextObject(ResponseManagementEvent.class);
 
     responseManagementEvent.getPayload().getCollectionCase().setCaseRef("123");
-    responseManagementEvent
-        .getPayload()
-        .getCollectionCase()
-        .setId("d09ac28e-d62f-4cdd-a5f9-e366e05f0fcd");
+    responseManagementEvent.getPayload().getCollectionCase().setId(UUID.randomUUID());
     responseManagementEvent.getPayload().getUac().setQuestionnaireId("123");
     responseManagementEvent.getPayload().getCollectionCase().setReceiptReceived(false);
     responseManagementEvent.getPayload().getCollectionCase().setRefusalReceived(null);
@@ -380,7 +377,7 @@ public class CaseAndUacReceiverTest {
   private Case getExpectedCase(CollectionCase collectionCase) {
     Case newCase = new Case();
     newCase.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
-    newCase.setCaseId(UUID.fromString(collectionCase.getId()));
+    newCase.setCaseId(collectionCase.getId());
     newCase.setCaseType(collectionCase.getCaseType());
     newCase.setActionPlanId(collectionCase.getActionPlanId());
     newCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());


### PR DESCRIPTION
# Motivation and Context
Use UUID data type to hold UUID data

# What has changed
Updated entity, dto and tests

# How to test?
- Build it and run it against the acceptance tests (master), with `use-UUID-type-for-UUId-data` branches of DDL, case-processor, action-scheduler, action-worker and action-processor.

# Links
- https://trello.com/c/r9qwqhaS