### PR TITLE
Additional paper UAC fulfilments

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiver.java
@@ -25,7 +25,10 @@ public class FulfilmentRequestReceiver {
               "P_OR_I4",
               "P_UAC_UACIP1",
               "P_UAC_UACIP2B",
-              "P_UAC_UACIP4"));
+              "P_UAC_UACIP4",
+              "P_UAC_UACIPA1",
+              "P_UAC_UACIPA2B",
+              "P_UAC_UACIPA4"));
   private final CaseRepository caseRepository;
   private final FulfilmentRequestService fulfilmentRequestService;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -75,6 +75,8 @@ public enum ActionType {
 
   P_ER_IL(ActionHandler.PRINTER), // Information leaflet
 
+  P_UAC_CX(ActionHandler.PRINTER), // CE Unique Access Codes via paper
+
   //  response driven interventions
   P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
   P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh

--- a/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
@@ -216,7 +216,13 @@ public class FulfilmentRequestService {
       case "P_UAC_UACIP1":
       case "P_UAC_UACIP2B":
       case "P_UAC_UACIP4":
+      case "P_UAC_UACIPA1":
+      case "P_UAC_UACIPA2B":
+      case "P_UAC_UACIPA4":
         return ActionType.P_UAC_IX;
+      case "P_UAC_UACCEP1":
+      case "P_UAC_UACCEP2B":
+        return ActionType.P_UAC_CX;
       default:
         log.with("fulfilmentCode", fulfilmentCode).warn("Unexpected fulfilment code received");
         return null;


### PR DESCRIPTION
# Motivation and Context
Additional paper fulfillments.  See https://collaborate2.ons.gov.uk/confluence/display/SDC/RM+Product+Library - rows 35-37, 41-42.

# What has changed
New fulfilment codes.

# How to test?
Run the `additional-paper-uac-fulfilments` branch of acceptance tests against this branch and the equivalent branches of case-processor, action-worker, action-scheduler and printfile service.

# Links
https://trello.com/c/TRqlAbsI