### PR TITLE
Use date type for dates

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/action/config/AppConfig.java
@@ -2,6 +2,8 @@ package uk.gov.ons.census.action.config;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
 import org.springframework.amqp.core.AmqpAdmin;
@@ -35,6 +37,8 @@ public class AppConfig {
   @Bean
   public Jackson2JsonMessageConverter messageConverter() {
     ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return new Jackson2JsonMessageConverter(objectMapper);
   }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Data;
 
@@ -8,6 +9,6 @@ public class Event {
   private EventType type;
   private String source;
   private String channel;
-  private String dateTime;
+  private OffsetDateTime dateTime;
   private UUID transactionId;
 }


### PR DESCRIPTION
# Motivation and Context
We want to take advantage of Java's strong typing, and to use `OffsetDateTime` for date types, not strings.

# What has changed
Changed anywhere that was using a string for date/time/timestamp to use `OffsetDateTime`.

# How to test?
Run the ATs - should be zero regression.

# Links
Trello: https://trello.com/c/PbcNYiWe