### PR TITLE
AddressTypeChange for CE Case ceActualResponses Defaulted to Zero

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -29,7 +29,7 @@ public class CollectionCase {
   private String fieldCoordinatorId;
   private String fieldOfficerId;
   private Integer ceExpectedCapacity;
-  private Integer ceActualResponses;
+  private int ceActualResponses;
   private Boolean receiptReceived;
   private RefusalType refusalReceived;
   private Boolean addressInvalid;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -81,7 +81,7 @@ public class Case {
 
   @Column private Integer ceExpectedCapacity;
 
-  @Column private Integer ceActualResponses;
+  @Column private int ceActualResponses;
 
   @Column private UUID collectionExerciseId;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -81,7 +81,8 @@ public class Case {
 
   @Column private Integer ceExpectedCapacity;
 
-  @Column private int ceActualResponses;
+  @Column(nullable = false)
+  private int ceActualResponses;
 
   @Column private UUID collectionExerciseId;
 


### PR DESCRIPTION
# Motivation and Context
When an AddressTypeChange event occurs where the new address is a CE Case, the ceActualResponses is null rather than 0 

# What has changed
Changed ceActualResponses from Integer to int so now defaults to 0 instead of null

# How to test?
Maven clean install on branch and check image builds and tests pass

# Links
https://trello.com/c/DUgevj8y