### PR TITLE
HOTFIX: Don't overwrite newer case data with older case data

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -100,9 +100,13 @@ public class CaseAndUacReceiver {
       throw new RuntimeException(String.format(CASE_NOT_FOUND_ERROR, caseId));
     }
 
-    Case updatedCase = cazeOpt.get();
-    setCaseDetails(collectionCase, updatedCase);
-    caseRepository.save(updatedCase);
+    Case caseToUpdate = cazeOpt.get();
+
+    // Make sure we throw away any updates which are older than the data we have already
+    if (collectionCase.getLastUpdated().isAfter(caseToUpdate.getLastUpdated())) {
+      setCaseDetails(collectionCase, caseToUpdate);
+      caseRepository.save(caseToUpdate);
+    }
   }
 
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {


### PR DESCRIPTION
# Motivation and Context
When we scale down the Action Processor, when we scale it back up it can process case updates in the wrong sequence, which replaces newer data with older data. This has caused havoc with the `receipt_received` flag, which often gets set only minutes later than the `survey_launched` flag.

This hotfix should reduce the problem and allow us to possibly scale down the Action Processor without having to worry about data corruption.

# What has changed
Check that the data that's being overwritten is not newer than the update which is being applied.

# How to test?
There's a unit test. Otherwise, you will need to generate a lot of launched/receipted events with the Action Processor scaled down, then scale it back up... the race condition problem will occur with a frequency of approximately 0.5% as seen in the wild.

# Links
Trello: https://trello.com/c/Hn1MSTyK